### PR TITLE
Design fixes

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -13,3 +13,7 @@
 .hero__body {
   padding: 0;
 }
+
+.homepage-services-and-info__list {
+  grid-template-rows: initial;
+}

--- a/index.html
+++ b/index.html
@@ -165,40 +165,42 @@
         class="govuk-section-break govuk-section-break--l govuk-section-break--visible"
       />
 
-      <div class="govuk-grid-row govuk-!-margin-bottom-7">
-        <div class="govuk-grid-column-one-half feature-column">
-          <section class="content-section">
-            <h2 class="govuk-heading-m content-section__first-heading">
-              Find out more about our work
-            </h2>
-            <p class="govuk-body">
-              To find out more you can read our blog posts about:
-            </p>
-            <ul class="govuk-list govuk-list--bullet">
-              <li>
-                <a
-                  class="govuk-link in-box"
-                  href="https://insidegovuk.blog.gov.uk/2022/07/04/opening-up-our-code-and-logic-for-algorithmic-decision-making/"
-                >Opening up our code and logic for algorithmic decision-making</a>
-              </li>
-              <li>
-                <a
-                  class="govuk-link in-box"
-                  href="https://insidegovuk.blog.gov.uk/2020/08/07/one-graph-to-rule-them-all/"
-                >One graph to rule them all</a>
-              </li>
-            </ul>
-          </section>
-        </div>
+      <div class="govuk-width-container">
 
-        <div class="govuk-grid-column-one-half feature-column">
-          <section class="content-section">
-            <h2 class="govuk-heading-m content-section__first-heading">
-              The Data Services team
-            </h2>
-            <p class="govuk-body">
-              Data Services are part of Product &amp; Technology in GDS
-            </p>
+        <div class="govuk-grid-row govuk-!-margin-bottom-7">
+          <div class="govuk-grid-column-one-half feature-column">
+            <section class="content-section">
+              <h2 class="govuk-heading-m content-section__first-heading">
+                Find out more about our work
+              </h2>
+              <p class="govuk-body">
+                To find out more you can read our blog posts about:
+              </p>
+              <ul class="govuk-list govuk-list--bullet">
+                <li>
+                  <a
+                    class="govuk-link in-box"
+                    href="https://insidegovuk.blog.gov.uk/2022/07/04/opening-up-our-code-and-logic-for-algorithmic-decision-making/"
+                  >Opening up our code and logic for algorithmic decision-making</a>
+                </li>
+                <li>
+                  <a
+                    class="govuk-link in-box"
+                    href="https://insidegovuk.blog.gov.uk/2020/08/07/one-graph-to-rule-them-all/"
+                  >One graph to rule them all</a>
+                </li>
+              </ul>
+            </section>
+          </div>
+
+          <div class="govuk-grid-column-one-half feature-column">
+            <section class="content-section">
+              <h2 class="govuk-heading-m content-section__first-heading">
+                The Data Services team
+              </h2>
+              <p class="govuk-body">
+                Data Services are part of Product &amp; Technology in GDS
+              </p>
 
                 </p>
                 <p class="govuk-body">
@@ -206,7 +208,8 @@
                   >Contact the Data Services team on Slack</a
                                                           >
                 </p>
-          </section>
+            </section>
+          </div>
         </div>
       </div>
     </main>


### PR DESCRIPTION
- The main page's bottom box lost its side margins when reformatting the markup previously
- The grid on the design page was set to have the same number of items as on gov.uk, but we need fewer